### PR TITLE
Append to an empty list if list is not present

### DIFF
--- a/src/parser/adapters/dynamo.coffee
+++ b/src/parser/adapters/dynamo.coffee
@@ -101,7 +101,7 @@ adaptations =
     action: 'SET'
     adapt: (entries) ->
       {
-        expression: "#{path_for(key)} = list_append(#{path_for(key)}, #{name_for(key)})"
+        expression: "#{path_for(key)} = list_append(if_not_exists(#{path_for(key), [])}, #{name_for(key)})"
         attributes: attrs_for key
         values: val_for key, value
       } for key, value of entries


### PR DESCRIPTION
Based on this SO answer:
https://stackoverflow.com/a/35001736/12958

The problem is if you try to enqueue to a set that isn't yet created then it will fail. This fixes that.